### PR TITLE
DEV-1841 Disable redirect from unused endpoint

### DIFF
--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/security/OpenIDResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/security/OpenIDResource.java
@@ -123,7 +123,6 @@ public class OpenIDResource extends Resource {
     val user = openidService.verify(token, receivingUrl, parameterList, redirect);
 
     return Response
-        //.seeOther(redirect)
         .header(SET_COOKIE, String.format(RESPONSE_HEADER_VALUE_TEMPLATE, setSessionCookie(user).toString()))
         .build();
   }

--- a/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/security/OpenIDResource.java
+++ b/dcc-portal-server/src/main/java/org/icgc/dcc/portal/server/resource/security/OpenIDResource.java
@@ -123,7 +123,7 @@ public class OpenIDResource extends Resource {
     val user = openidService.verify(token, receivingUrl, parameterList, redirect);
 
     return Response
-        .seeOther(redirect)
+        //.seeOther(redirect)
         .header(SET_COOKIE, String.format(RESPONSE_HEADER_VALUE_TEMPLATE, setSessionCookie(user).toString()))
         .build();
   }


### PR DESCRIPTION
We should not be using the API endpoint that has been modified so it
should be safe to disable the redirect. Unfortunately it is probably
best tested _in situ_ in production.

One danger of leaving this redirect intact is that an attacker could
send a legitimate-looking link to an HMF employee, say requesting
support, then try to phish login information by spoofing one of our
actual login pages (nevermind that this application does not require
authentication itself).