### PR TITLE
DEV-1842 Do not display tooltips verbatim in HTML

### DIFF
--- a/dcc-portal-ui/app/scripts/ui/js/tooltip.js
+++ b/dcc-portal-ui/app/scripts/ui/js/tooltip.js
@@ -83,7 +83,7 @@
 
         function handleShow(evt, params) {
           if (params.text) {
-            scope.html = $sce.trustAsHtml(params.text);
+            scope.html = $sce.getTrustedHtml(params.text);
           }
           if (params.placement) {
             scope.placement = params.placement;


### PR DESCRIPTION
The application allows a user to upload their own custom data and assign
an arbitrary name to it. The name is displayed in tooltips in the UI.
This allows injection of arbitrary code which could be used in an
attack.

This is best tested in situ in production as there may be other
similar calls that have to be fixed, and I am not fully confident of the
fix without having been able to test in development.